### PR TITLE
ENH Add draft for epix100 calibration.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,6 +80,7 @@ libxtcpp_base = shared_library(
     [
         'src/common/datasource.cc',
         'src/common/detector.cc',
+        'src/common/detector_utils.cc',
         'src/common/bd_reader.cc',
         'src/common/smd_reader.cc',
         'src/util/threadpool.cc',

--- a/src/app/jungfrau_reader.cc
+++ b/src/app/jungfrau_reader.cc
@@ -118,9 +118,9 @@ int main(int argc, char* argv[]) {
 
       if (run_calib && raw_jungfrau) {
         //auto calib_jungfrau = XTCPP::calibrate(jungfrau->data_ptrs(), jungfrau->calibconst_span());
-        XTCPP::calibrate(jungfrau->data_ptrs(),
-                         jungfrau->calibconst_span(),
-                         jungfrau->calib_data_buf());
+        XTCPP::calibrate_jungfrau(jungfrau->data_ptrs(),
+                                  jungfrau->calibconst_span(),
+                                  jungfrau->calib_data_buf());
 
         if (test_smd && n_events % 1 == 0) {
           //std::vector<std::float32_t> dat_to_write(calib_jungfrau.begin(),

--- a/src/common/detector.cc
+++ b/src/common/detector.cc
@@ -1,6 +1,7 @@
 #include "common/detector.hh"
 
 #include "common/bd_reader.hh"
+#include "common/detector_utils.hh"
 
 #include "xtcdata/xtc/Dgram.hh"
 #include "xtcdata/xtc/TransitionId.hh"
@@ -24,89 +25,6 @@
 #include <vector>
 
 namespace XTCPP {
-  void calibrate(std::vector<void*>& data_ptrs,
-		 std::span<CalibStruct>& calibconst,
-		 std::vector<std::float32_t>& calib_data) {
-    auto data_mask = 0x3FFF;
-    constexpr size_t NSEGS{32};
-    constexpr size_t NROWS{512};
-    constexpr size_t NCOLS{1024};
-    constexpr size_t NPIX {NSEGS * NROWS * NCOLS};
-    constexpr size_t PIX_PER_SEG {NROWS * NCOLS};
-
-    #pragma omp parallel for schedule(static)
-    for (size_t seg=0; seg < NSEGS; ++seg) {
-      auto* raw_data = reinterpret_cast<std::uint16_t*>(data_ptrs[seg]);
-
-      for (size_t panel_idx=0; panel_idx < PIX_PER_SEG; ++panel_idx) {
-        size_t idx = seg*PIX_PER_SEG + panel_idx;
-
-        uint16_t raw_pixel = raw_data[panel_idx];
-        uint16_t data = raw_pixel & data_mask;
-        size_t gain_idx = raw_pixel >> 14; // Top two bits
-        if (gain_idx > 1) {
-          if (gain_idx == 2) [[unlikely]] {
-            /* This is 0b10 - a bad pixel, hopefully unlikely - what should happen? */
-            continue;
-          } else [[likely]] {
-            gain_idx--; // Map gain_idx 3 (0b11 - low gain) to index 2
-          }
-        }
-        size_t calib_idx = gain_idx * NPIX + idx;
-
-        if (calib_idx >= calibconst.size()) {
-          std::cerr << "Invalid calib_idx: " << calib_idx << ", size is: " << calibconst.size()
-                    << ", gain idx is: " << gain_idx << std::endl;
-          continue;
-        }
-        calib_data[idx] =
-          (data - calibconst[calib_idx].ped) * calibconst[calib_idx].gain;
-      }
-    }
-  }
-
-  std::vector<std::float32_t> calibrate(std::vector<void*>& data_ptrs,
-                                        std::span<CalibStruct>& calibconst) {
-    auto data_mask = 0x3FFF;
-    constexpr size_t NSEGS{32};
-    constexpr size_t NROWS{512};
-    constexpr size_t NCOLS{1024};
-    constexpr size_t NPIX {NSEGS * NROWS * NCOLS};
-    constexpr size_t PIX_PER_SEG {NROWS * NCOLS};
-
-    std::vector<std::float32_t> data_out(32*512*1024);
-
-#pragma omp parallel for schedule(static)
-    for (size_t idx=0; idx < NPIX; ++idx) {
-      size_t seg = idx / PIX_PER_SEG;
-      size_t panel_idx = idx % PIX_PER_SEG;
-
-      auto* raw_data = reinterpret_cast<std::uint16_t*>(data_ptrs[seg]);
-      uint16_t raw_pixel = raw_data[panel_idx];
-      uint16_t data = raw_pixel & data_mask;
-      size_t gain_idx = raw_pixel >> 14; // Top two bits
-      if (gain_idx > 1) {
-        if (gain_idx == 2) [[unlikely]] {
-          /* This is 0b10 - a bad pixel, hopefully unlikely - what should happen? */
-          continue;
-        } else [[likely]] {
-          gain_idx--; // Map gain_idx 3 (0b11 - low gain) to index 2
-        }
-      }
-      size_t calib_idx = gain_idx * NPIX + idx;
-
-      if (calib_idx >= calibconst.size()) {
-        std::cerr << "Invalid calib_idx: " << calib_idx << ", size is: " << calibconst.size()
-                  << ", gain idx is: " << gain_idx << std::endl;
-        continue;
-      }
-      data_out[idx] =
-        (data - calibconst[calib_idx].ped) * calibconst[calib_idx].gain;
-    }
-
-    return data_out;
-  }
-
   namespace Base {
     Detector::Detector(std::string detname,
                        std::string serial_no,
@@ -125,7 +43,6 @@ namespace XTCPP {
       , m_xtc_readers(xtc_readers)
       , m_data_ptrs(m_segment_nos.size())
       , m_data_sizes(m_segment_nos.size())
-      , m_calib_data(32*512*1024)
       , m_is_epics(is_epics)
       , m_is_scan(is_scan)
     {
@@ -157,6 +74,12 @@ namespace XTCPP {
       } else {
         m_det_algs = reader->det_algs()[m_detname];
         m_det_alg_fields = reader->det_alg_fields()[m_detname];
+      }
+
+      if (m_det_type == "jungfrau") {
+        m_calib_data = std::vector<std::float32_t>(32 * 512 * 1024);
+      } else if (m_det_type == "epix100") {
+        m_calib_data = std::vector<std::float32_t>(704 * 768);
       }
     }
 

--- a/src/common/detector.hh
+++ b/src/common/detector.hh
@@ -1,7 +1,8 @@
 #ifndef XTCPP_BASE_DETECTOR_HH
 #define XTCPP_BASE_DETECTOR_HH
 
-#include "bd_reader.hh"
+#include "common/bd_reader.hh"
+#include "common/detector_utils.hh"
 
 #include "../util/threadpool.hh"
 
@@ -22,43 +23,6 @@
 #include <vector>
 
 namespace XTCPP {
-
-  /**
-   * Holds a single set of constants required to calibrate a pixel.
-   * A vector/array etc of these structs would be required to calibrate a full
-   * detector image.
-   */
-  #pragma pack(push,1)
-  class CalibStruct {
-  public:
-    std::float32_t ped;  ///< Holds pedestal + offset should an offset exist
-    std::float32_t gain; ///< Holds the gain value in keV/ADU
-  };
-  #pragma pack(pop)
-
-  /**
-   * Calibrate a detector image
-   * @param[in] data_ptrs A vector of per segment/module raw data.
-   * @param[in] calibconst The calibration constants. Should be a 1 dimensional
-   *            span with a length equal to the total number of pixels. I.e. it
-   *            is not per segment like the data_ptrs vector.
-   * @return calib_data The calibrated data.
-   */
-  std::vector<std::float32_t> calibrate(std::vector<void*>& data_ptrs,
-                                        std::span<CalibStruct>& calibconst);
-
-  /**
-   * Calibrate a detector image
-   * @param[in] data_ptrs A vector of per segment/module raw data.
-   * @param[in] calibconst The calibration constants. Should be a 1 dimensional
-   *            span with a length equal to the total number of pixels. I.e. it
-   *            is not per segment like the data_ptrs vector.
-   * @param[out] calib_data An output buffer to hold the calibrated data.
-   */
-  void calibrate(std::vector<void*>& data_ptrs,
-		 std::span<CalibStruct>& calibconst,
-		 std::vector<std::float32_t>& calib_data);
-
   namespace Base {
     /**
      * The detector class provides a convenience wrapper around a set of BDReader
@@ -204,6 +168,8 @@ namespace XTCPP {
        */
       std::map<std::pair<std::string,unsigned>, std::vector<DataField>>
       alg_fields() const { return m_det_alg_fields; }
+
+      std::string det_type() const { return m_det_type; }
 
     protected:
       /**

--- a/src/common/detector_utils.cc
+++ b/src/common/detector_utils.cc
@@ -1,0 +1,117 @@
+#include "detector_utils.hh"
+
+#include <cstdint>
+#include <span>
+#include <stdfloat>
+#include <string>
+#include <vector>
+
+namespace XTCPP {
+  void calibrate(std::string dettype,
+                 std::vector<void*>& data_ptrs,
+                 std::span<CalibStruct>& calibconst,
+                 std::vector<std::float32_t>& calib_data) {
+    if (dettype == "jungfrau") {
+      calibrate_jungfrau(data_ptrs, calibconst, calib_data);
+    } else if (dettype == "epix100") {
+      calibrate_epix100(data_ptrs, calibconst, calib_data);
+    }
+  }
+
+  void calibrate_jungfrau(std::vector<void*>& data_ptrs,
+                          std::span<CalibStruct>& calibconst,
+                          std::vector<std::float32_t>& calib_data) {
+    auto data_mask = 0x3FFF;
+    constexpr size_t NSEGS{32};
+    constexpr size_t NROWS{512};
+    constexpr size_t NCOLS{1024};
+    constexpr size_t NPIX {NSEGS * NROWS * NCOLS};
+    constexpr size_t PIX_PER_SEG {NROWS * NCOLS};
+
+    #pragma omp parallel for schedule(static)
+    for (size_t seg=0; seg < NSEGS; ++seg) {
+      auto* raw_data = reinterpret_cast<std::uint16_t*>(data_ptrs[seg]);
+
+      for (size_t panel_idx=0; panel_idx < PIX_PER_SEG; ++panel_idx) {
+        size_t idx = seg*PIX_PER_SEG + panel_idx;
+
+        uint16_t raw_pixel = raw_data[panel_idx];
+        uint16_t data = raw_pixel & data_mask;
+        size_t gain_idx = raw_pixel >> 14; // Top two bits
+        if (gain_idx > 1) {
+          if (gain_idx == 2) [[unlikely]] {
+            /* This is 0b10 - a bad pixel, hopefully unlikely - what should happen? */
+            continue;
+          } else [[likely]] {
+            gain_idx--; // Map gain_idx 3 (0b11 - low gain) to index 2
+          }
+        }
+        size_t calib_idx = gain_idx * NPIX + idx;
+
+        if (calib_idx >= calibconst.size()) {
+          continue;
+        }
+        calib_data[idx] =
+          (data - calibconst[calib_idx].ped) * calibconst[calib_idx].gain;
+      }
+    }
+  }
+
+  void calibrate_epix100(std::vector<void*>& data_ptrs,
+                         std::span<CalibStruct>& calibconst,
+                         std::vector<std::float32_t>& calib_data) {
+
+    constexpr size_t NROWS{704};
+    constexpr size_t NCOLS{768};
+    constexpr size_t NPIX {NROWS * NCOLS};
+    auto* raw_data = reinterpret_cast<std::uint16_t*>(data_ptrs[0]);
+
+    for (size_t idx=0; idx < NPIX; ++idx) {
+      uint16_t data = raw_data[idx];
+      calib_data[idx] = (data - calibconst[idx].ped) * calibconst[idx].gain;
+    }
+  }
+
+  std::vector<std::float32_t> calibrate_jungfrau(std::vector<void*>& data_ptrs,
+                                                 std::span<CalibStruct>& calibconst) {
+    auto data_mask = 0x3FFF;
+    constexpr size_t NSEGS{32};
+    constexpr size_t NROWS{512};
+    constexpr size_t NCOLS{1024};
+    constexpr size_t NPIX {NSEGS * NROWS * NCOLS};
+    constexpr size_t PIX_PER_SEG {NROWS * NCOLS};
+
+    std::vector<std::float32_t> data_out(32*512*1024);
+
+    #pragma omp parallel for schedule(static)
+    for (size_t seg = 0; seg < NSEGS; ++seg) {
+      auto* raw_data = reinterpret_cast<std::uint16_t*>(data_ptrs[seg]);
+
+      for (size_t panel_idx = 0; panel_idx < PIX_PER_SEG; ++panel_idx) {
+        size_t idx = seg * PIX_PER_SEG + panel_idx;
+
+        uint16_t raw_pixel = raw_data[panel_idx];
+        uint16_t data = raw_pixel & data_mask;
+        size_t gain_idx = raw_pixel >> 14; // Top two bits
+        if (gain_idx > 1) {
+          if (gain_idx == 2) [[unlikely]] {
+            /* This is 0b10 - a bad pixel, hopefully unlikely - what should
+             * happen? */
+            continue;
+          } else [[likely]] {
+            gain_idx--; // Map gain_idx 3 (0b11 - low gain) to index 2
+          }
+        }
+        size_t calib_idx = gain_idx * NPIX + idx;
+
+        if (calib_idx >= calibconst.size()) {
+          continue;
+        }
+        data_out[idx] =
+          (data - calibconst[calib_idx].ped) * calibconst[calib_idx].gain;
+      }
+    }
+
+    return data_out;
+  }
+} // namespace XTCPP

--- a/src/common/detector_utils.hh
+++ b/src/common/detector_utils.hh
@@ -1,0 +1,77 @@
+#ifndef XTCPP_BASE_DETECTOR_UTIL_HH
+#define XTCPP_BASE_DETECTOR_UTIL_HH
+
+#include <cstdint>
+#include <span>
+#include <stdfloat>
+#include <string>
+#include <vector>
+
+namespace XTCPP {
+
+  /**
+   * Holds a single set of constants required to calibrate a pixel.
+   * A vector/array etc of these structs would be required to calibrate a full
+   * detector image.
+   */
+  #pragma pack(push,1)
+  class CalibStruct {
+  public:
+    std::float32_t ped;  ///< Holds pedestal + offset should an offset exist
+    std::float32_t gain; ///< Holds the gain value in keV/ADU
+  };
+  #pragma pack(pop)
+
+  /**
+   * Calibrate a detector image
+   * @param[in] dettype The detector type in order to call the correct calibration
+   *            function.
+   * @param[in] data_ptrs A vector of per segment/module raw data.
+   * @param[in] calibconst The calibration constants. Should be a 1 dimensional
+   *            span with a length equal to the total number of pixels. I.e. it
+   *            is not per segment like the data_ptrs vector.
+   * @param[out] calib_data An output buffer to hold the calibrated data.
+   */
+  void calibrate(std::string dettype,
+                 std::vector<void*>& data_ptrs,
+                 std::span<CalibStruct>& calibconst,
+                 std::vector<std::float32_t>& calib_data);
+
+  /**
+   * Calibrate a Jungfrau detector image
+   * @param[in] data_ptrs A vector of per segment/module raw data.
+   * @param[in] calibconst The calibration constants. Should be a 1 dimensional
+   *            span with a length equal to the total number of pixels. I.e. it
+   *            is not per segment like the data_ptrs vector.
+   * @return calib_data The calibrated data.
+   */
+  void calibrate_jungfrau(std::vector<void*>& data_ptrs,
+                          std::span<CalibStruct>& calibconst,
+                          std::vector<std::float32_t>& calib_data);
+
+  /**
+   * Calibrate an ePix100 detector image.
+   * @param[in] data_ptrs A vector of per segment/module raw data.
+   * @param[in] calibconst The calibration constants. Should be a 1 dimensional
+   *            span with a length equal to the total number of pixels. I.e. it
+   *            is not per segment like the data_ptrs vector.
+   * @param[out] calib_data An output buffer to hold the calibrated data.
+   */
+  void calibrate_epix100(std::vector<void*>& data_ptrs,
+                         std::span<CalibStruct>& calibconst,
+                         std::vector<std::float32_t>& calib_data);
+
+  /**
+   * Calibrate a Jungfrau detector image
+   * @param[in] data_ptrs A vector of per segment/module raw data.
+   * @param[in] calibconst The calibration constants. Should be a 1 dimensional
+   *            span with a length equal to the total number of pixels. I.e. it
+   *            is not per segment like the data_ptrs vector.
+   * @return calib_data The calibrated data.
+   */
+  std::vector<std::float32_t> calibrate_jungfrau(std::vector<void*>& data_ptrs,
+                                                 std::span<CalibStruct>& calibconst);
+
+} // namespace XTCPP
+
+#endif // XTCPP_BASE_DETECTOR_UTIL_HH

--- a/src/python/pyxtcpp.cc
+++ b/src/python/pyxtcpp.cc
@@ -1,9 +1,12 @@
-#include "common/smd_reader.hh"
 #include "common/bd_reader.hh"
+#include "common/detector.hh"
+#include "common/detector_utils.hh"
+#include "common/smd_reader.hh"
+
+#include "hdf5/mpiwriter.hh"
+#include "mpi/bd_reader.hh"
 #include "mpi/datasource.hh"
 #include "mpi/detector.hh"
-#include "mpi/bd_reader.hh"
-#include "hdf5/mpiwriter.hh"
 #include "mpi/smd_reader.hh"
 
 #include "xtcdata/xtc/ShapesData.hh"
@@ -316,29 +319,48 @@ namespace {
           py_alg_setattr(field.name.c_str(), MethodType(get_field_method, py_alg));
 
           // TODO: Implement a better method for calib method...
-          if (alg_name == "raw" && detname == "jungfrau") {
+          std::string det_type = det->det_type();
+          if (alg_name == "raw" && (det_type == "jungfrau" || det_type == "epix100")) {
             auto calib_method =
-              py::cpp_function([](AlgWrapper& self, size_t evt) -> py::object {
+              py::cpp_function([det_type](AlgWrapper& self, size_t evt) -> py::object {
                 auto alg_det = self.det;
                 [[maybe_unused]] auto raw_data = alg_det->get_l1_data(evt,
                                                                       "raw",
                                                                       "raw");
-                XTCPP::calibrate(alg_det->data_ptrs(),
+                XTCPP::calibrate(det_type,
+                                 alg_det->data_ptrs(),
                                  alg_det->calibconst_span(),
                                  alg_det->calib_data_buf());
 
-                size_t nsegs{32};
-                size_t nrows{512};
-                size_t ncols{1024};
-                std::vector<size_t> shape{nsegs, nrows, ncols};
-                std::vector<size_t> strides(3);
-                strides[2] = sizeof(float);
-                strides[1] = ncols * strides[2];
-                strides[0] = nrows * strides[1];
+                size_t ndim;
+                std::vector<size_t> shape;
+                std::vector<size_t> strides;
+                if (det_type == "jungfrau") {
+                  size_t nsegs{32};
+                  size_t nrows{512};
+                  size_t ncols{1024};
+                  ndim = 3;
+                  shape = std::vector<size_t>{nsegs, nrows, ncols};
+                  strides = std::vector<size_t>(3);
+                  strides[2] = sizeof(float);
+                  strides[1] = ncols * strides[2];
+                  strides[0] = nrows * strides[1];
+                } else if (det_type == "epix100") {
+                  size_t nrows{704};
+                  size_t ncols{768};
+                  ndim = 2;
+                  shape = std::vector<size_t>{nrows, ncols};
+                  strides = std::vector<size_t>(2);
+                  strides[1] = sizeof(float);
+                  strides[0] = nrows * strides[1];
+                } else {
+                  // This shouldn't happen...
+                  return py::object(py::cast(nullptr));
+                }
                 return py::array_t<float>(py::buffer_info(reinterpret_cast<float*>(alg_det->calib_data_buf().data()),
                                                           sizeof(float),
                                                           py::format_descriptor<float>::format(),
-                                                          3,
+                                                          ndim,
                                                           shape,
                                                           strides));
               });


### PR DESCRIPTION
As title. Reorganizes calibrate functions to provide a version for ePix100, in C++ and at the Python bindings level.

Python bindings still need work (but all the infrastructure and shapes should be in place).