### PR TITLE
ENH Optimize multi-segment array construction in Python bindings.

### DIFF
--- a/src/common/bd_reader.hh
+++ b/src/common/bd_reader.hh
@@ -226,7 +226,7 @@ namespace XTCPP {
       /**
        * The map of detector names to segment numbers for the data in this XTC2 file.
        */
-      std::map<std::string, std::vector<unsigned>> segment_numbers() const { return m_segment_nos; }
+      const std::map<std::string, std::vector<unsigned>>& segment_numbers() const { return m_segment_nos; }
 
       /**
        * The map of detector names to serial numbers for the data in this XTC2 file.

--- a/src/common/detector.cc
+++ b/src/common/detector.cc
@@ -427,8 +427,8 @@ namespace XTCPP {
       }
       if (have_data) {
         m_last_index_read = static_cast<ssize_t>(offset_idx);
-        std::vector<unsigned> reader_seg_nos =
-            reader->segment_numbers()["scan"];
+        const auto& reader_seg_nos =
+            reader->segment_numbers().at("scan");
         unsigned seg_no = reader_seg_nos[0]; // There should only be 1
         auto [data_ptr, data_size, rank, shape] =
           reader->get_data(m_detname, seg_no, alg, data_name);
@@ -465,8 +465,8 @@ namespace XTCPP {
         m_last_index_read = static_cast<ssize_t>(offset_idx);
         // Data is stored under "epics" detector. The algorithm
         // is always "raw" and the field name is the PV name - our m_detname
-        std::vector<unsigned> reader_seg_nos =
-          reader->segment_numbers()["epics"];
+        const auto& reader_seg_nos =
+          reader->segment_numbers().at("epics");
         unsigned seg_no = reader_seg_nos[0]; // There should only be 1
         std::string epics_detname{"epics"};
         std::string epics_alg{"raw"};
@@ -503,8 +503,8 @@ namespace XTCPP {
         auto ret = reader->read_l1_at(offset_idx);
         bool set_rank_and_shape {true};
         if (ret.has_value()) {
-          std::vector<unsigned> reader_seg_nos =
-              reader->segment_numbers()[m_detname];
+          const auto& reader_seg_nos =
+              reader->segment_numbers().at(m_detname);
           auto seg_no_it = reader_seg_nos.begin();
           while (seg_no_it != reader_seg_nos.end()) {
             auto [data_ptr, data_size, rank, shape] =
@@ -568,8 +568,8 @@ namespace XTCPP {
         auto ret = reader->read_l1_at(offset_idx);
         bool set_rank_and_shape {true};
         if (ret.has_value()) {
-          std::vector<unsigned> reader_seg_nos =
-              reader->segment_numbers()[m_detname];
+          const auto& reader_seg_nos =
+              reader->segment_numbers().at(m_detname);
           auto seg_no_it = reader_seg_nos.begin();
           while (seg_no_it != reader_seg_nos.end()) {
             auto [data_ptr, data_size, rank, shape] =
@@ -652,7 +652,7 @@ namespace XTCPP {
         auto ret = reader->wait();
         if (ret.has_value()) {
           //m_logger->trace("** Have a non-null dgram return. Now accessing the data field.");
-          std::vector<unsigned> reader_seg_nos = reader->segment_numbers()[m_detname];
+          const auto& reader_seg_nos = reader->segment_numbers().at(m_detname);
           auto seg_no_it = reader_seg_nos.begin();
           while (seg_no_it != reader_seg_nos.end()) {
             auto [data_ptr, data_size, rank, shape] =
@@ -721,7 +721,7 @@ namespace XTCPP {
         auto ret = reader->wait();
         if (ret.has_value()) {
           //m_logger->trace("** Have a non-null dgram return. Now accessing the data field.");
-          std::vector<unsigned> reader_seg_nos = reader->segment_numbers()[m_detname];
+          const auto& reader_seg_nos = reader->segment_numbers().at(m_detname);
           auto seg_no_it = reader_seg_nos.begin();
           while (seg_no_it != reader_seg_nos.end()) {
             auto [data_ptr, data_size, rank, shape] =

--- a/src/common/smd_reader.hh
+++ b/src/common/smd_reader.hh
@@ -210,7 +210,7 @@ namespace XTCPP
       /**
        * The map of detector names to segment numbers for the data in this XTC2 file.
        */
-      std::map<std::string, std::vector<unsigned>> segment_numbers() const { return m_segment_nos; }
+      const std::map<std::string, std::vector<unsigned>>& segment_numbers() const { return m_segment_nos; }
 
       /**
        * The map of detector names to serial numbers for the data in this XTC2 file.

--- a/src/mpi/datasource.cc
+++ b/src/mpi/datasource.cc
@@ -143,7 +143,7 @@ namespace XTCPP {
           serial_nos.push_back(ser_no);
           segments.push_back(seg_no);
         } else {
-          auto det_reader_segs = det_reader->segment_numbers()[detname];
+          const auto& det_reader_segs = det_reader->segment_numbers().at(detname);
           auto det_reader_sernos = det_reader->serial_numbers()[detname];
           // These two should be the same size
           if (det_reader_segs.size() != det_reader_sernos.size()) {

--- a/src/python/pyxtcpp.cc
+++ b/src/python/pyxtcpp.cc
@@ -19,6 +19,7 @@
 
 #include <any>
 #include <cstdint>
+#include <cstring>
 #include <iostream>
 #include <memory>
 #include <stdfloat>
@@ -130,20 +131,29 @@ namespace {
                                                 arrshape,
                                                 strides));
         } else {
-          // TODO: Make this multi-segment code not need a copy??
-          py::list segment_arrays;
-          // Boo... this will cause a copy at the end when the segments are put
-          // into a single array :(
-          for (size_t seg=0; seg < nsegs; ++seg) {
-            segment_arrays.append(py::array_t<T>(py::buffer_info(reinterpret_cast<T**>(val)[seg],
-                                                                 sizeof(T),
-                                                                 py::format_descriptor<T>::format(),
-                                                                 rank - 1,
-                                                                 arrshape,
-                                                                 strides)));
+          // Allocate a single contiguous array and memcpy each segment directly,
+          // avoiding the previous py::list approach which caused N+1 copies.
+          std::vector<size_t> full_shape;
+          full_shape.reserve(rank);
+          full_shape.push_back(nsegs);
+          full_shape.insert(full_shape.end(), arrshape.begin(), arrshape.end());
 
+          std::vector<size_t> full_strides(rank);
+          full_strides[rank - 1] = sizeof(T);
+          for (ssize_t j = static_cast<ssize_t>(rank) - 2; j >= 0; --j) {
+            full_strides[j] = full_strides[j + 1] * full_shape[j + 1];
           }
-          return py::array_t<T>(segment_arrays);
+
+          py::array_t<T> result(full_shape, full_strides);
+          T* dst = result.mutable_data();
+          size_t seg_bytes = full_strides[0];
+          size_t seg_elems = seg_bytes / sizeof(T);
+          for (size_t seg = 0; seg < nsegs; ++seg) {
+            std::memcpy(dst + seg * seg_elems,
+                        reinterpret_cast<T**>(val)[seg],
+                        seg_bytes);
+          }
+          return result;
         }
       }
       /* Complex case - "PIL" style -- see the actual Python docs for this one */


### PR DESCRIPTION
# Description

Optimizes the Python binding performance for multi-segment detectors (e.g. Jungfrau)
by addressing two sources of overhead identified via benchmarking.

## Context

Benchmarking xtcpp vs psana2 on `mfx101344525` run 70 (Jungfrau, ~4800 events, ~157 GB)
showed that while xtcpp's C++ binary is 2-5x faster than psana2, the Python bindings
were at parity or slower. Profiling the Python binding path revealed two main culprits:

1. **Multi-segment array copy (~33 MB/event):** `handle_scalar_or_array()` in
   `pyxtcpp.cc` built a `py::list` of N segment arrays, then called `py::array_t(list)`
   which internally invokes `numpy.array(list)` — causing N+1 heap allocations and
   copying all segment data twice (~66 MB touched per event for Jungfrau).

2. **Map copy per event per reader:** `segment_numbers()` returned
   `std::map<std::string, std::vector<unsigned>>` by value, causing a full map copy
   on each of the 6 reader calls per event.

## Changes

1. **Single-allocation direct memcpy** (`src/python/pyxtcpp.cc`):
   Replace the `py::list` + `py::array_t(list)` pattern with a single contiguous
   `py::array_t` allocation using the full `(nsegs, ...)` shape, then `std::memcpy`
   each segment directly into the correct offset. Reduces to 1 allocation + N memcpys.

2. **Return `segment_numbers()` by const reference** (`bd_reader.hh`, `smd_reader.hh`):
   Changed return type to `const std::map<...>&`. Updated all 7 call sites in
   `detector.cc` and `datasource.cc` from `operator[]` to `.at()`.

## PR Type:
- [x] Enhancement

## Address issues:
Resolves the `TODO` at the multi-segment copy site:
```cpp
// TODO: Make this multi-segment code not need a copy??
```

# Testing

## Benchmark

Tested on sdfmilan263 (AMD EPYC 7713P 64-Core, 503 GB RAM, SLURM Job 22654120) with
`mfx101344525` run 70, Jungfrau detector, raw mode, `XTCPP_MPIDS_IDXMODE=FAST`.

### Total throughput (events/second, all workers combined)

| MPI Ranks | psana2       | xtcpp-py (before) | xtcpp-py (after) | xtcpp C++    |
|-----------|-------------|-------------------|------------------|-------------|
| 4         | ~111 (2 BD) | ~109 (4)          | **~278** (4)     | ~411 (4)    |
| 8         | ~206 (6 BD) | ~171 (8)          | **~322** (8)     | ~483 (8)    |
| 16        | ~235 (14 BD)| ~226 (16)         | **~324** (16)    | ~494 (16)   |
| 32        | ~281 (29 BD)| ~272 (32)         | **~394** (32)    | ~481 (32)   |

### Per-worker event rate (events/second)

| MPI Ranks | psana2 (per BD) | xtcpp-py (per worker) | xtcpp C++ (per worker) |
|-----------|----------------|----------------------|----------------------|
| 4         | ~56            | **~70**              | ~103                 |
| 8         | ~34            | **~40**              | ~60                  |
| 16        | ~17            | **~20**              | ~31                  |
| 32        | ~10            | **~12**              | ~15                  |

### Key result

xtcpp Python bindings go from **parity with psana2 to 1.4-2.5x faster** across all
rank counts. The gap to xtcpp C++ narrows from ~4x to ~1.5-2x.

### Remaining optimization opportunities

- **Buffer cache** (like psana2's `_raw_buf`): reuse the numpy array across events to
  eliminate the remaining per-event allocation. Deferred because it changes semantics
  (previous event arrays get overwritten).
- **Read coalescing**: coalesce contiguous event reads into fewer MPI-IO calls (psana2
  issues ~16x fewer syscalls via its `pread()` coalescing).

### Launch command
```bash
XTCPP_MPIDS_IDXMODE=FAST srun --jobid=${JOBID} --overlap -n 4 --mpi=pmix     python -B examples/test_pytiming.py -e mfx101344525 -r 70
```

# Screenshots
NA